### PR TITLE
Add error buffer for LP subprocesses

### DIFF
--- a/transient-extras-lp.el
+++ b/transient-extras-lp.el
@@ -164,7 +164,8 @@ arguments that should be passed to `lp'"
                      :name "printing"
                      :buffer nil
                      :connection-type 'pipe
-                     :command cmd)))
+                     :command cmd
+                     :stderr "*printing errors*")))
       (when (bufferp buf-or-files)
         ;; Send the buffer content to the process
         (process-send-string process


### PR DESCRIPTION
Otherwise, any error output is hidden from the user, which makes debugging difficult.

I didn't use the a2ps print menu yet, but its process call is

``` emacs-lisp

(make-process
 :name "a2ps-print"
 :buffer buffer
 :stderr buffer
 :connection-type 'pipe
 :command cmd)
```

so it also shows you the stderr in a buffer. For lp the normal stdout might not
be so useful, so it's fine not having and stdout buffer there, but I would prefer having the *stderr* in a separate buffer.

What I haven't implemented yet but would be nice is to also give a warning in case of an error with a hint to check out the error buffer for more information. Like what `magit` does if a commit or push fails.